### PR TITLE
Fix for error that shows up with certain URLs

### DIFF
--- a/MediaRenderer_Player.groovy
+++ b/MediaRenderer_Player.groovy
@@ -241,6 +241,8 @@ def parse(description) {
 							def metaDataLoad = trackMeta  ? trackMeta : transportMeta
                             def metaData = metaDataLoad?.startsWith("<item") ?  "<DIDL-Lite xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" xmlns:dlna=\"urn:schemas-dlna-org:metadata-1-0/\">$metaDataLoad</DIDL-Lite>": metaDataLoad 
 							metaData = metaData.contains("dlna:dlna") &&  !metaData.contains("xmlns:dlna") ? metaData.replace("<DIDL-Lite"," <DIDL-Lite xmlns:dlna=\"urn:schemas-dlna-org:metadata-1-0/\"") : metaData
+							metaData = metaData.replace("&", "&amp;")
+
 							def stationMetaXml = metaData ? parseXml(metaData) : null
 							
 							


### PR DESCRIPTION
Change '&'s in the track metadata to "&amp;" to prevent errors in XML parsing. I noticed this issue when playing radio stations on the Striim Light Wifi Color.
